### PR TITLE
fix(MFTD-1126): redact github token from lambda error logs + document release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,17 +53,33 @@ $ docker-compose run tf-codebuild-github-status npm run lint
 ## Building
 Bundles the function into `dist/index.js` using [esbuild](https://esbuild.github.io/). The AWS SDK v3 is excluded from the bundle because the lambda runtime provides it.
 ```shell
+# bundle only
 $ npm run build
+
+# bundle and produce the deployable artifact dist/index.zip
+# (index.js must sit at the zip root — the lambda handler is "index.handler")
+$ npm run package
 ```
 
 ## Releasing
-1. Merge fixes & features to master
-1. Run lint check `npm run lint`
-1. Run security check `npm run sec`
-1. Run full test suite `npm test`
-1. Run release script `npm run release`
-1. Push release & release tag to github `git push --follow-tags`
-1. [Publish new release](https://help.github.com/articles/creating-releases/) in github, using the release notes from the [CHANGELOG](./CHANGELOG.md)
+`master` is protected (PR-only, linear history), so the release tool must never create the tag itself: a tag made on a branch dangles once the PR is squash-merged, because the squash commit gets a new SHA. Version on a branch, then tag `master` after the merge.
+
+1. Ensure everything is green: `npm run lint && npm test && npm run sec`
+1. On a release branch, run `npm run release -- --skip.tag true` — bumps `package.json`/`package-lock.json` and the [CHANGELOG](./CHANGELOG.md) and commits, but does **not** tag. If the automatic bump picks the wrong version, add `--release-as X.Y.Z` (the version must be higher than every existing tag — the tag line is already past `v2.0.0`)
+1. Push the branch, open a PR to `master`, and squash-merge it
+1. Tag the squash commit on master and push the tag:
+    ```shell
+    $ git fetch origin
+    $ git tag -a vX.Y.Z -m "chore(release): X.Y.Z" origin/master
+    $ git push origin vX.Y.Z
+    ```
+1. Build the artifact and upload it to the shared ops artifacts bucket under a **new version path** (the bucket name is in the S3 console or the `s3-artifacts-ops-<region>` TFE workspace outputs):
+    ```shell
+    $ npm run package
+    $ aws s3 cp dist/index.zip s3://<artifacts-bucket>/tf-codebuild-github-status/vX.Y.Z/index.zip
+    ```
+1. [Publish a release](https://help.github.com/articles/creating-releases/) in github using the CHANGELOG notes
+1. Deploy via Terraform Enterprise (see [Deploying](#deploying))
 
 ## Configuring
 Define custom configuration
@@ -86,23 +102,34 @@ $ aws ssm put-parameter --name /secrets/codebuild-trigger/custom --type SecureSt
 ```
 
 ## Deploying
-Via terraform
+Our lambda is deployed by a **Terraform Enterprise workspace** that runs this repo's `terraform/` directory directly as a root module — from the **`terraform-enterprise` branch**, not from `master`. That branch carries the modern (0.12+) syntax, pins `required_version >= 1.4.2` and `hashicorp/aws >= 6.0`, and sets the lambda runtime (`nodejs24.x`). The workspace supplies `name`, `region`, `config_parameter_names`, `s3_bucket`, `s3_key`, and AWS credentials (`access_key`/`secret_key`, from the org variable set) as Terraform variables.
+
+To deploy a new code version:
+1. Complete the [release steps](#releasing) so the artifact exists at `tf-codebuild-github-status/vX.Y.Z/index.zip` in the artifacts bucket
+1. Update the workspace's `s3_key` variable to the new version path. The `aws_lambda_function` resource has no `source_code_hash`, so **changing `s3_key` is what triggers the code redeploy** — re-uploading to the same key deploys nothing
+1. Queue a plan and read it before applying: a code-only deploy should show one in-place update of the lambda function and **0 to destroy**
+1. Verify from the Lambda console (Test tab):
+    - a non-PR event `{ "detail": { "additional-information": { "source-version": "v1.0.0" } } }` should succeed with `"event:success"` — proves runtime, bundle, and SSM config
+    - the fixture [test/fixtures/build-state-change.json](./test/fixtures/build-state-change.json) should **fail with a GitHub 404** for `my-repo` — that is the pass signal, proving the GitHub client authenticated with the token from SSM (a 401/403 means the token needs rotating)
+
+Terraform *module* changes (anything under `terraform/`) also belong on the `terraform-enterprise` branch. Other repos (e.g. `tf-buildpipeline`) consume `terraform/` as a module pinned to immutable git refs (`//terraform?ref=v1.0.2`, `ref=terraform-1.x.x-compatible`) — never move or rewrite those tags/branches; existing consumers resolve them live.
+
+For reference, consuming this as a module from another root looks like:
 ```
 module "codebuild_trigger" {
-  source                     = "git::git@github.com:cludden/tf-codebuild-github-status.git//terraform?ref={version}"
-  config_parameter_name      = "/secrets/codebuild-trigger"
-  debug                      = ""
-  memory_size                = 128
-  name                       = "codebuild-github-status"
-  node_env                   = "production"
-  region                     = "us-west-2"
-  s3_bucket                  = "my-artifact-bucket"
-  s3_key                     = "tf-codebuild-github-status/${var.version}/index.zip"
-  timeout                    = 10
+  source                 = "git::git@github.com:Mindflash/tf-codebuild-github-status.git//terraform?ref={version}"
+  config_parameter_names = "/secrets/codebuild-trigger"
+  memory_size            = 128
+  name                   = "codebuild-github-status"
+  node_env               = "production"
+  region                 = "us-east-1"
+  s3_bucket              = "my-artifact-bucket"
+  s3_key                 = "tf-codebuild-github-status/${var.version}/index.zip"
+  timeout                = 10
 }
 ```
 
-Note: Terraform for this function is executed from the `terraform-enterprise` branch, not from this branch. This codebase targets the `nodejs24.x` Lambda runtime, so the runtime there should be updated to match. AWS Lambda manages patch versions within a runtime family, so patch-level pinning (for example, `24.4.0`) is not configurable in Terraform.
+Note: AWS Lambda manages patch versions within a runtime family, so patch-level pinning (for example, `24.4.0`) is not configurable in Terraform.
 
 ## License
 Licensed under the [MIT License](LICENSE.md)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "rm -rf dist && esbuild src/index.js --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.js --sourcemap --external:@aws-sdk/* --external:dtrace-provider --external:mv --external:safe-json-stringify",
     "coverage": "c8 --reporter=lcov --reporter=text npm test",
     "lint": "eslint .",
+    "package": "npm run build && cd dist && zip index.zip index.js index.js.map",
     "release": "commit-and-tag-version",
     "sec": "npm audit --omit=dev",
     "test": "BUNYAN_NO_DTRACE=1 CONFIG_PARAMETER_NAMES=foo,bar LOG_LEVEL=fatal NODE_ENV=test mocha --recursive 'test/**/*.test.js'"

--- a/src/http.js
+++ b/src/http.js
@@ -31,6 +31,12 @@ export default function (config, log) {
       const payload = err?.config?.data;
       const msg = `${method} -- ${url} failed with status (${status}) and data: ${JSON.stringify(data)}`;
       log.error({ data: payload }, msg);
+      // the lambda runtime serializes unhandled errors (via AxiosError.toJSON)
+      // into cloudwatch logs, request config included — strip credentials so
+      // the github token never reaches the logs
+      if (err?.config?.headers) {
+        err.config.headers.Authorization = '[redacted]';
+      }
       return Promise.reject(err);
     },
   );

--- a/src/http.js
+++ b/src/http.js
@@ -29,14 +29,14 @@ export default function (config, log) {
       const method = err?.config?.method ?? 'UNKNOWN';
       const url = err?.config?.url;
       const payload = err?.config?.data;
-      const msg = `${method} -- ${url} failed with status (${status}) and data: ${JSON.stringify(data)}`;
-      log.error({ data: payload }, msg);
       // the lambda runtime serializes unhandled errors (via AxiosError.toJSON)
-      // into cloudwatch logs, request config included — strip credentials so
-      // the github token never reaches the logs
+      // into cloudwatch logs, request config included — strip credentials
+      // before anything logs so the github token can never reach the logs
       if (err?.config?.headers) {
         err.config.headers.Authorization = '[redacted]';
       }
+      const msg = `${method} -- ${url} failed with status (${status}) and data: ${JSON.stringify(data)}`;
+      log.error({ data: payload }, msg);
       return Promise.reject(err);
     },
   );

--- a/test/tests/basic.test.js
+++ b/test/tests/basic.test.js
@@ -189,5 +189,7 @@ describe('basic', function () {
     expect(err).to.have.nested.property('response.status', 500);
     expect(spy.callCount).to.equal(1);
     expect(spy.firstCall.args[1]).to.match(/failed with status \(500\)/);
+    expect(err.config.headers.Authorization).to.equal('[redacted]');
+    expect(JSON.stringify(err.toJSON())).to.not.include(this.config.get('github.token'));
   });
 });


### PR DESCRIPTION
## Summary
- **Security fix**: the Lambda runtime serializes unhandled AxiosErrors (via `toJSON`) into CloudWatch Logs, request config included — which wrote the live GitHub token to the log group on every unhandled API failure. The http interceptor now redacts the `Authorization` header before propagating the error. The error-path test asserts the serialized error no longer contains the token.
- **Docs**: the README now documents the real release and deploy process learned during the v2.0.0 rollout — protected-master release flow (`--skip.tag` + tag-after-merge), artifact packaging/upload to the shared artifacts bucket, and the TFE workspace deploy (`s3_key` change triggers the redeploy) with console smoke tests.
- Adds an `npm run package` script producing the deployable `dist/index.zip`.

## Context
Found during the v2.0.0 verification invoke: the runtime's "Invoke Error" log line contained the plaintext GitHub token. The token itself is being rotated separately; this prevents the new one from leaking the same way.

## Test plan
- [x] `npm test` — 10 passing, including the strengthened error test (`err.toJSON()` contains no token, header shows `[redacted]`)
- [x] `npm run lint` clean
- [x] `npm run package` produces `dist/index.zip` with `index.js` at the zip root

🤖 Generated with [Claude Code](https://claude.com/claude-code)