### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [2.0.1](https://github.com/cludden/tf-codebuild-github-status/compare/v2.0.0...v2.0.1) (2026-08-05)
+
+### Bug Fixes
+
+* **MFTD-1126:** redact github token from lambda error logs + document release process ([#6](https://github.com/cludden/tf-codebuild-github-status/issues/6)) ([51d160e](https://github.com/cludden/tf-codebuild-github-status/commit/51d160edab2d4cfcfff0d3daae158a9cfa75616c))
 ## [2.0.0](https://github.com/cludden/tf-codebuild-github-status/compare/v1.0.3...v2.0.0) (2026-08-04)
 <a name="1.0.0"></a>
 # [1.0.0](https://github.com/cludden/tf-codebuild-github-status/compare/v1.0.0-beta.2...v1.0.0) (2018-08-27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tf-codebuild-github-status",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tf-codebuild-github-status",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-ssm": "^3.1098.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tf-codebuild-github-status",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "a node.js lambda function that updates github commit statuses based on codebuild events",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release v2.0.1 — version bump and CHANGELOG only, per the release process documented in the README (tag is applied to master after this merges, not on this branch).

## Changes in this release
- fix(MFTD-1126): redact github token from lambda error logs + document release process (#6)

## After merge
1. Tag master: `git tag -a v2.0.1 -m "chore(release): 2.0.1" origin/master && git push origin v2.0.1`
2. `npm run package` and upload to `s3://<artifacts-bucket>/tf-codebuild-github-status/v2.0.1/index.zip`
3. Flip the TFE workspace `s3_key` variable and apply
4. Rotate the GitHub token in SSM

🤖 Generated with [Claude Code](https://claude.com/claude-code)